### PR TITLE
fix: add missing link to CPN22  profil in partenaires page

### DIFF
--- a/www/data.php
+++ b/www/data.php
@@ -200,7 +200,7 @@ $data_partenaires = array (
    array(
       "Coopérative22",
       "img/coop22.png",
-      "",
+      "https://twitter.com/cpn22",
       "La coopérative, c’est :
       <ul><li>l’ensemble des établissements scolaires du département qui peuvent accueillir ou proposer des animations autour du numérique</li>
           <li>un point central : les sites pilotes qui fédèrent l’ensemble des initiatives du terrain et proposent de nombreuses animations et temps d’échanges entre pairs</li>


### PR DESCRIPTION
Ajout d'un lien hypertexte pointant vers le profil Twitter de la CPN22 (à défaut d'un site web). C'est le seul partenaire n'ayant aucune page référencée jusque là.